### PR TITLE
Fix a couple of cargo warnings and make the tests/examples actually c…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,23 @@ codegen-units = 1
 [[example]]
 name = "cursor"
 required-features = ["std"]
-path = "cursor.rs"
+
+[[example]]
+name = "json"
+
+[[example]]
+name = "http"
+required-features = ["std"]
 
 [[test]]
 name = "http"
 required-features = ["std"]
-path = "http.rs"
+
+[[test]]
+name = "pouet"
+
+[[test]]
+name = "combinators-json"
 
 [badges]
 travis-ci = { repository = "Geal/cookie-factory" }


### PR DESCRIPTION
…ompile

cursor.rs and http.rs could not be found because they were specified by
filename instead of the full relative path. We don't have to provide
the filename or path at all if it's the same as the name of the target.

And cargo was complaining about the examples/tests inference behaviour
changes between Rust 2015 and 2018. Fixed by explicitly listing all
tests and examples that should be compiled/run in Cargo.toml.