### PR TITLE
Don't calculate/return the written size from each combinator

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -57,7 +57,7 @@ mod macros {
 
     let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
     let index = {
-      let (buf, index) = cf_request((&mut buffer, 0), &request).unwrap();
+      let (buf, index) = cf_request((&mut buffer[..], 0), &request).unwrap();
 
       println!("result:\n{}", str::from_utf8(buf).unwrap());
 
@@ -94,21 +94,20 @@ mod functions {
     let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
     let ptr = {
       let sr = fn_request(&request);
-      let buf = sr(&mut buffer).unwrap();
+      let buf = sr(&mut buffer[..]).unwrap();
 
       //println!("result:\n{}", str::from_utf8(buf).unwrap());
 
       buf.as_ptr() as usize
     };
 
-    let index = ptr - (&buffer[..]).as_ptr() as usize;
+    let index = ptr - buffer.as_ptr() as usize;
 
     println!("wrote {} bytes", index);
     b.bytes = index as u64;
     b.iter(|| {
       let sr = fn_request(&request);
-      let res = sr(&mut buffer).unwrap();
-      assert_eq!(res.as_ptr() as usize, ptr);
+      sr(&mut buffer[..]).unwrap();
     });
   }
 }

--- a/benches/json-functions.rs
+++ b/benches/json-functions.rs
@@ -101,9 +101,9 @@ fn json_test() {
 
   let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
   let pos = {
-    let mut sr = gen_json_value(&value);
+    let sr = gen_json_value(&value);
 
-    let res = sr(&mut buffer).unwrap();
+    let res = sr(&mut buffer[..]).unwrap();
     res.as_ptr() as usize
   };
 
@@ -134,7 +134,7 @@ fn functions_json(b: &mut Bencher) {
   let pos = {
     let sr = gen_json_value(&value);
 
-    let res = sr(&mut buffer).unwrap();
+    let res = sr(&mut buffer[..]).unwrap();
     res.as_ptr() as usize
   };
 
@@ -143,7 +143,7 @@ fn functions_json(b: &mut Bencher) {
   b.bytes = index as u64;
   b.iter(|| {
     let sr = gen_json_value(&value);
-    let _ = sr(&mut buffer).unwrap();
+    let _ = sr(&mut buffer[..]).unwrap();
   });
 }
 
@@ -154,7 +154,7 @@ fn functions_gen_str(b: &mut Bencher) {
   let pos = {
     let sr = gen_str(&"hello");
 
-    let res = sr(&mut buffer).unwrap();
+    let res = sr(&mut buffer[..]).unwrap();
     res.as_ptr() as usize
   };
 
@@ -163,6 +163,6 @@ fn functions_gen_str(b: &mut Bencher) {
   b.bytes = index as u64;
   b.iter(|| {
     let sr = gen_str(&"hello");
-    let _ = sr(&mut buffer).unwrap();
+    let _ = sr(&mut buffer[..]).unwrap();
   });
 }

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -19,14 +19,11 @@ fn main() {
   };
 
 
-  let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
+  let sr = fn_request(&request);
+  let writer = cookie_factory::WriteCounter::new(vec![]);
+  let writer = sr(writer).unwrap();
+  let (buffer, size) = writer.into_inner();
 
-  let size = {
-    let sr = fn_request(&request);
-    let (_buf, size) = sr(&mut buffer).unwrap();
-    size
-  };
-
-  println!("result:\n{}", str::from_utf8(&buffer[..size]).unwrap());
+  println!("result:\n{}", str::from_utf8(&buffer[..(size as usize)]).unwrap());
 }
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -8,6 +8,8 @@ use std::{str, iter::repeat};
 use implementation::*;
 
 fn main() {
+  use cookie_factory::lib::std::io::Cursor;
+
   let element = JsonValue::Object(btreemap!{
     String::from("arr") => JsonValue::Array(vec![JsonValue::Num(1.0), JsonValue::Num(12.3), JsonValue::Num(42.0)]),
     String::from("b") => JsonValue::Boolean(true),
@@ -20,13 +22,12 @@ fn main() {
 
   let value = JsonValue::Array(repeat(element).take(10).collect::<Vec<JsonValue>>());
 
-  let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
-
-  let size = {
-    let sr = gen_json_value(&value);
-    let (_, size) = sr(&mut buffer).unwrap();
-    size
-  };
+  let mut buffer = [0u8; 8192];
+  let sr = gen_json_value(&value);
+  let writer = Cursor::new(&mut buffer[..]);
+  let writer = sr(writer).unwrap();
+  let size = writer.position() as usize;
+  let buffer = writer.into_inner();
 
   println!("result:\n{}", str::from_utf8(&buffer[..size]).unwrap());
 }

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -327,7 +327,7 @@ pub fn le_u24<W: Write>(i: u32) -> impl SerializeFn<W> {
    let len = 3;
 
     move |mut out: W| {
-        try_write!(out, len, &i.to_le_bytes()[1..])
+        try_write!(out, len, &i.to_le_bytes()[0..3])
     }
 }
 

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -300,11 +300,11 @@ pub fn be_i64<W: Write>(i: i64) -> impl SerializeFn<W> {
 }
 
 pub fn be_f32<W: Write>(i: f32) -> impl SerializeFn<W> {
-    be_u32(unsafe { ::lib::std::mem::transmute::<f32, u32>(i) })
+    be_u32(i.to_bits())
 }
 
 pub fn be_f64<W: Write>(i: f64) -> impl SerializeFn<W> {
-    be_u64(unsafe { ::lib::std::mem::transmute::<f64, u64>(i) })
+    be_u64(i.to_bits())
 }
 
 pub fn le_u8<W: Write>(i: u8) -> impl SerializeFn<W> {
@@ -368,11 +368,11 @@ pub fn le_i64<W: Write>(i: i64) -> impl SerializeFn<W> {
 }
 
 pub fn le_f32<W: Write>(i: f32) -> impl SerializeFn<W> {
-    le_u32(unsafe { ::lib::std::mem::transmute::<f32, u32>(i) })
+    le_u32(i.to_bits())
 }
 
 pub fn le_f64<W: Write>(i: f64) -> impl SerializeFn<W> {
-    le_u64(unsafe { ::lib::std::mem::transmute::<f64, u64>(i) })
+    le_u64(i.to_bits())
 }
 
 /// applies a generator over an iterator of values, and applies the serializers generated

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -34,7 +34,8 @@ pub fn legacy_wrap<'a, G>(gen: G, x: (&'a mut [u8], usize)) -> Result<(&'a mut [
       let (buf, offset) = x;
       let start = buf.as_mut_ptr();
       let buf_len = buf.len();
-      let len = gen(&mut buf[offset..]).map(|tup| tup.1)?;
+      let end = gen(&mut buf[offset..])?;
+      let len = buf_len - offset - end.len();
       let buf = unsafe { ::lib::std::slice::from_raw_parts_mut(start, buf_len) };
       Ok((buf, offset + len))
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -6,6 +6,7 @@ use implementation::*;
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::io::Cursor;
   use std::str::from_utf8;
 
   #[test]
@@ -29,14 +30,13 @@ mod tests {
     println!("request written by cf:\n{}", from_utf8(&s[..index]).unwrap());
 
     let mut mem2: [u8; 1024] = [0; 1024];
-    let ptr = {
-      let s2 = &mut mem2[..];
-
-      let mut sr = fn_request(&request);
-      let (res, _) = sr(s2).unwrap();
-      res.as_ptr() as usize
+    let (mem2, index2) = {
+      let sr = fn_request(&request);
+      let writer = Cursor::new(&mut mem2[..]);
+      let writer = sr(writer).unwrap();
+      let index2 = writer.position() as usize;
+      (writer.into_inner(), index2)
     };
-    let index2 = ptr - (&mem2[..]).as_ptr() as usize;
     println!("request written by fn:\n{}", from_utf8(&mem2[..index2]).unwrap());
     println!("wrote {} bytes", index2);
 


### PR DESCRIPTION
See https://github.com/rust-bakery/cookie-factory/issues/18

Needs tests to be fixed and I'm not super happy with the `length` and `position` combinators as they won't advance the slice like everything else would be doing. And they only work on mutable slices, not anything else, which I'd like to fix by introducing a new trait for them if the two functions are something we'd want to keep.

The tests for the legacy API in `src/gen.rs` are all passing with this.

@Geal @Keruspe If this looks like it's going into a good direction to you then I'd continue working on this. Also I was wondering if the legacy API in `src/gen.rs` should maybe be deprecated?