### PR TITLE
Remove WriteCounter and add a WriteContext that is passed around with…

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -74,6 +74,7 @@ mod macros {
 
 mod functions {
   use super::*;
+  use cookie_factory::{gen, gen_simple};
 
   #[bench]
   fn http(b: &mut Bencher) {
@@ -91,22 +92,20 @@ mod functions {
 
 
     let mut buffer = repeat(0).take(16384).collect::<Vec<u8>>();
-    let ptr = {
+    let index = {
       let sr = fn_request(&request);
-      let buf = sr(&mut buffer[..]).unwrap();
+      let (_, pos) = gen(sr, &mut buffer[..]).unwrap();
 
       //println!("result:\n{}", str::from_utf8(buf).unwrap());
 
-      buf.as_ptr() as usize
+      pos as usize
     };
-
-    let index = ptr - buffer.as_ptr() as usize;
 
     println!("wrote {} bytes", index);
     b.bytes = index as u64;
     b.iter(|| {
       let sr = fn_request(&request);
-      sr(&mut buffer[..]).unwrap();
+      let _ = gen_simple(sr, &mut buffer[..]).unwrap();
     });
   }
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,7 +1,7 @@
 extern crate cookie_factory;
 
 use std::io::{Write, sink};
-use cookie_factory::{WriteCounter, SerializeFn, pair, string};
+use cookie_factory::{SerializeFn, pair, string, gen, gen_simple};
 
 fn serializer<W: Write>() -> impl SerializeFn<W> {
   pair(string("Hello "), string("World!"))
@@ -9,14 +9,14 @@ fn serializer<W: Write>() -> impl SerializeFn<W> {
 
 fn main() {
   let s = {
-    let mut c = WriteCounter::new(sink());
+    let c = sink();
     let ser = serializer();
-    match ser(&mut c) {
+    match gen(ser, c) {
       Err(e) => {
         panic!("error calculating the length to serialize: {:?}", e);
       },
-      Ok(w) => {
-        w.position() as usize
+      Ok((_, pos)) => {
+        pos as usize
       }
     }
   };
@@ -27,7 +27,7 @@ fn main() {
   let v = {
     let v = Vec::with_capacity(s);
     let ser = serializer();
-    match ser(v) {
+    match gen_simple(ser, v) {
       Err(e) => {
         panic!("error serializing: {:?}", e);
       },

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -4,6 +4,7 @@ extern crate cookie_factory;
 use crate::implementation::*;
 
 fn main() {
+  use cookie_factory::gen;
   let request = Request {
     method: "GET",
     uri: "/hello/test/a/b/c?name=value#hash",
@@ -18,9 +19,8 @@ fn main() {
 
 
   let sr = fn_request(&request);
-  let writer = cookie_factory::WriteCounter::new(vec![]);
-  let writer = sr(writer).unwrap();
-  let (buffer, size) = writer.into_inner();
+  let writer = vec![];
+  let (buffer, size) = gen(sr, writer).unwrap();
 
   println!("result:\n{}", std::str::from_utf8(&buffer[..(size as usize)]).unwrap());
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -9,6 +9,7 @@ use crate::implementation::*;
 
 fn main() {
   use cookie_factory::lib::std::io::Cursor;
+  use cookie_factory::gen_simple;
 
   let element = JsonValue::Object(btreemap!{
     String::from("arr") => JsonValue::Array(vec![JsonValue::Num(1.0), JsonValue::Num(12.3), JsonValue::Num(42.0)]),
@@ -25,7 +26,7 @@ fn main() {
   let mut buffer = [0u8; 8192];
   let sr = gen_json_value(&value);
   let writer = Cursor::new(&mut buffer[..]);
-  let writer = sr(writer).unwrap();
+  let writer = gen_simple(sr, writer).unwrap();
   let size = writer.position() as usize;
   let buffer = writer.into_inner();
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -43,7 +43,7 @@ pub fn legacy_wrap<'a, G>(gen: G, x: (&'a mut [u8], usize)) -> Result<(&'a mut [
       let (buf, offset) = {
           let mut cursor = io::Cursor::new(buf);
           cursor.set_position(offset as u64);
-          let cursor = gen(cursor)?;
+          let cursor = gen_simple(gen, cursor)?;
           let position = cursor.position();
           (cursor.into_inner(), position)
       };

--- a/tests/combinators-json.rs
+++ b/tests/combinators-json.rs
@@ -9,6 +9,7 @@ use crate::implementation::*;
 fn json_test() {
   use std::str;
   use cookie_factory::lib::std::io::Cursor;
+  use cookie_factory::gen_simple;
 
   let value = JsonValue::Object(btreemap!{
     String::from("arr") => JsonValue::Array(vec![JsonValue::Num(1.0), JsonValue::Num(12.3), JsonValue::Num(42.0)]),
@@ -25,7 +26,7 @@ fn json_test() {
   let mut buffer = [0u8; 8192];
   let sr = gen_json_value(&value);
   let writer = Cursor::new(&mut buffer[..]);
-  let writer = sr(writer).unwrap();
+  let writer = gen_simple(sr, writer).unwrap();
   let size = writer.position() as usize;
   let buffer = writer.into_inner();
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -8,6 +8,7 @@ mod tests {
   use super::*;
   use std::io::Cursor;
   use std::str::from_utf8;
+  use cookie_factory::gen_simple;
 
   #[test]
   fn request() {
@@ -33,7 +34,7 @@ mod tests {
     let (mem2, index2) = {
       let sr = fn_request(&request);
       let writer = Cursor::new(&mut mem2[..]);
-      let writer = sr(writer).unwrap();
+      let writer = gen_simple(sr, writer).unwrap();
       let index2 = writer.position() as usize;
       (writer.into_inner(), index2)
     };


### PR DESCRIPTION
… the SerializeFns

Also add gen() and gen_simple() helper functions to run a SerializeFn.

Fixes https://github.com/rust-bakery/cookie-factory/issues/27

----

CC @Keruspe 

Would something like this work for you? I've commented out some stuff and the doctests are all still failing, but the examples and other tests should give an idea how this can be used.