### PR TITLE
Help cargo find the new license file location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "cookie-factory"
 version = "0.3.3"
 authors = ["Geoffroy Couprie <geo.couprie@gmail.com>", "Pierre Chifflier <chifflier@wzdftpd.net>"]
 license = "MIT"
+license-file = "LICENSES/MIT.txt"
 repository = "https://github.com/rust-bakery/cookie-factory"
 readme = "README.md"
 documentation = "http://docs.rs/cookie-factory"


### PR DESCRIPTION
`cargo` did not pick up the license file now that it's moved to `LICENSES/` per the REUSE specification.

Explicitly tell it where the license file is so it's included for distro packaging.

```
michel in cookie-factory on  restore-license [!] is 📦 v0.3.3 via 🦀 v1.82.0 took 18s
⬢ [fedora-packaging] ❯ cargo package --list --no-verify --allow-dirty | grep LICENSE
LICENSES/MIT.txt
```