### PR TITLE
update future crates to non-yanked versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,5 @@ travis-ci = { repository = "Geal/cookie-factory" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-futures-io = { version = "0.3.30", optional = true }
-futures-util = { version = "0.3.30", optional = true, features = ["io"]}
+futures-io = { version = "0.3.31", optional = true }
+futures-util = { version = "0.3.31", optional = true, features = ["io"]}


### PR DESCRIPTION
Version 0.3.30 was yanked on crates.io causing warnings when downstream projects depend on them.